### PR TITLE
Add subdomains redirections

### DIFF
--- a/dockerize/sites-enabled/prod-ssl.conf
+++ b/dockerize/sites-enabled/prod-ssl.conf
@@ -264,11 +264,11 @@ server {
     return 301 $scheme://hub.qgis.org/models$request_uri;
 }
 
-# Redirect 3d.qgis.org to hub.qgis.org/wavefronts
+# Redirect 3d-models.qgis.org to hub.qgis.org/wavefronts
 server {
     listen 80;
     listen 443 ssl;
-    server_name 3d.qgis.org;
+    server_name 3d-models.qgis.org;
     ssl_certificate /etc/letsencrypt/live/hub.qgis.org/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/hub.qgis.org/privkey.pem;
     return 301 $scheme://hub.qgis.org/wavefronts$request_uri;

--- a/dockerize/sites-enabled/prod-ssl.conf
+++ b/dockerize/sites-enabled/prod-ssl.conf
@@ -223,3 +223,63 @@ server {
         allow all;
   	}
 }
+
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name hub-analytics.qgis.org;
+    ssl_certificate /etc/letsencrypt/live/hub.qgis.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hub.qgis.org/privkey.pem;
+    return 301 $scheme://hub.qgis.org/metabase/public/dashboard/7ecd345f-7321-423d-9844-71e526a454a9;
+}
+
+
+# Redirect styles.qgis.org to hub.qgis.org/styles
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name styles.qgis.org;
+    ssl_certificate /etc/letsencrypt/live/hub.qgis.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hub.qgis.org/privkey.pem;
+    return 301 $scheme://hub.qgis.org/styles$request_uri;
+}
+
+# Redirect projects.qgis.org to hub.qgis.org/geopackages
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name projects.qgis.org;
+    ssl_certificate /etc/letsencrypt/live/hub.qgis.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hub.qgis.org/privkey.pem;
+    return 301 $scheme://hub.qgis.org/geopackages$request_uri;
+}
+
+# Redirect models.qgis.org to hub.qgis.org/models
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name models.qgis.org;
+    ssl_certificate /etc/letsencrypt/live/hub.qgis.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hub.qgis.org/privkey.pem;
+    return 301 $scheme://hub.qgis.org/models$request_uri;
+}
+
+# Redirect 3d.qgis.org to hub.qgis.org/wavefronts
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name 3d.qgis.org;
+    ssl_certificate /etc/letsencrypt/live/hub.qgis.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hub.qgis.org/privkey.pem;
+    return 301 $scheme://hub.qgis.org/wavefronts$request_uri;
+}
+
+# Redirect qlr.qgis.org to hub.qgis.org/layerdefinitions
+server {
+    listen 80;
+    listen 443 ssl;
+    server_name qlr.qgis.org;
+    ssl_certificate /etc/letsencrypt/live/hub.qgis.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hub.qgis.org/privkey.pem;
+    return 301 $scheme://hub.qgis.org/layerdefinitions$request_uri;
+}


### PR DESCRIPTION
Redirections for:

- hub-analytics.qgis.org 
- styles.qgis.org
- projects.qgis.org
- models.qgis.org
- 3d.qgis.org
- qlr.qgis.org