### PR TITLE
Fix processing script error 500

### DIFF
--- a/qgis-app/processing_scripts/urls.py
+++ b/qgis-app/processing_scripts/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
         ProcessingScriptRequireActionListView.as_view(),
         name="processing_script_require_action",
     ),
-    path("tags/<processing_script_tag>/", ProcessingScriptByTagView.as_view(), name="processing_script_tag"),
+    path("tags/<processing_script_tag>/", ProcessingScriptByTagView.as_view(), name="processingscript_tag"),
     # JSON
     path("sidebarnav/", processing_script_nav_content, name="processing_script_nav_content"),
 ]


### PR DESCRIPTION
This should fix the following error:

```
django.urls.exceptions.NoReverseMatch: Reverse for 'processingscript_tag' not found. 'processingscript_tag' is not a valid view function or pattern name.
```