### PR TITLE
Add ProcessingScript model support and related API endpoints

### DIFF
--- a/HUB_API.md
+++ b/HUB_API.md
@@ -6,6 +6,15 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 
 ## Endpoints
 
+### Available resource types (resource_type)
+- `geopackage`
+- `3dmodel`
+- `style`
+- `layerdefinition`
+- `model`
+- `map`
+- `processingscript`
+
 ### Resources
 - **URL:** `/resources/`
 - **Method:** `GET`

--- a/qgis-app/api/serializers.py
+++ b/qgis-app/api/serializers.py
@@ -6,6 +6,7 @@ from styles.models import Style, StyleType
 from layerdefinitions.models import LayerDefinition
 from wavefronts.models import WAVEFRONTS_STORAGE_PATH, Wavefront
 from map_gallery.models import Map
+from processing_scripts.models import ProcessingScript
 from sorl.thumbnail import get_thumbnail
 from django.conf import settings
 from os.path import exists, join
@@ -222,6 +223,14 @@ class WavefrontSerializer(ResourceBaseSerializer):
 class MapSerializer(ResourceBaseSerializer):
     class Meta(ResourceBaseSerializer.Meta):
         model = Map
+
+    def get_resource_subtype(self, obj):
+        return None
+
+
+class ProcessingScriptSerializer(ResourceBaseSerializer):
+    class Meta(ResourceBaseSerializer.Meta):
+        model = ProcessingScript
 
     def get_resource_subtype(self, obj):
         return None

--- a/qgis-app/api/views.py
+++ b/qgis-app/api/views.py
@@ -6,7 +6,8 @@ from api.serializers import (
     StyleSerializer,
     LayerDefinitionSerializer,
     WavefrontSerializer,
-    MapSerializer
+    MapSerializer,
+    ProcessingScriptSerializer
 )
 from base.license import zip_a_file_if_not_zipfile
 from django.contrib.postgres.search import SearchVector
@@ -41,6 +42,7 @@ from styles.models import Style
 from layerdefinitions.models import LayerDefinition
 from wavefronts.models import Wavefront
 from map_gallery.models import Map
+from processing_scripts.models import ProcessingScript
 from api.models import UserOutstandingToken
 from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
 
@@ -164,6 +166,11 @@ class ResourceAPIList(FlatMultipleModelAPIView):
             "serializer_class": MapSerializer,
             "filter_fn": filter_general,
         },
+        {
+            "queryset": ProcessingScript.approved_objects.all(),
+            "serializer_class": ProcessingScriptSerializer,
+            "filter_fn": filter_general,
+        },
 
     ]
 
@@ -189,6 +196,10 @@ class ResourceAPIDownload(APIView):
             object = LayerDefinition.approved_objects.get(uuid=uuid)
         elif Wavefront.approved_objects.filter(uuid=uuid).exists():
             object = Wavefront.approved_objects.get(uuid=uuid)
+        elif Map.approved_objects.filter(uuid=uuid).exists():
+            object = Map.approved_objects.get(uuid=uuid)
+        elif ProcessingScript.approved_objects.filter(uuid=uuid).exists():
+            object = ProcessingScript.approved_objects.get(uuid=uuid)
         else:
             raise Http404
 
@@ -375,6 +386,8 @@ def _get_resource_serializer(resource_type):
         return ModelSerializer
     elif resource_type.lower() == "map":
         return MapSerializer
+    elif resource_type.lower() == "processingscript":
+        return ProcessingScriptSerializer
     else:
         return None
 
@@ -391,6 +404,8 @@ def _get_resource_object(uuid, resource_type):
         return get_object_or_404(Model.approved_objects, uuid=uuid)
     elif resource_type.lower() == "map":
         return get_object_or_404(Map.approved_objects, uuid=uuid)
+    elif resource_type.lower() == "processingscript":
+        return get_object_or_404(ProcessingScript.approved_objects, uuid=uuid)
     else:
         return None
 

--- a/qgis-app/processing_scripts/urls.py
+++ b/qgis-app/processing_scripts/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
         ProcessingScriptRequireActionListView.as_view(),
         name="processing_script_require_action",
     ),
-    path("tags/<processing_script_tag>/", ProcessingScriptByTagView.as_view(), name="processing_script_tag"),
+    path("tags/<processing_script_tag>/", ProcessingScriptByTagView.as_view(), name="processingscript_tag"),
     # JSON
     path("sidebarnav/", processing_script_nav_content, name="processing_script_nav_content"),
 ]


### PR DESCRIPTION
Fix for #63 

This will add the Map and Processing Script types to the Hub API:

- For the Map, the resource type label is `map`. For example: https://hub.qgis.org/api/v1/resources/?resource_type=map
- For the Processing Script, the resource type label is `processingscript`. For example: https://hub.qgis.org/api/v1/resources/?resource_type=processingscript

They are also described in the `HUB_API.md` file. I will work on the swagger later.

Cc @ismailsunni