### PR TITLE
Add upload size limit in each resource type

### DIFF
--- a/qgis-app/base/forms/processing_forms.py
+++ b/qgis-app/base/forms/processing_forms.py
@@ -1,7 +1,8 @@
+import os
+
 from base.validator import filesize_validator
 from django import forms
 from django.utils.translation import gettext_lazy as _
-import os
 
 
 class ResourceBaseReviewForm(forms.Form):
@@ -21,13 +22,13 @@ class ResourceBaseReviewForm(forms.Form):
         super(ResourceBaseReviewForm, self).__init__(*args, **kwargs)
         self.fields["comment"].widget = forms.Textarea(
             attrs={
-            "placeholder": _(
-                "Please provide clear feedback if you decided to not "
-                "approve this %s."
-            )
-            % self.resource_name,
-            "rows": "5",
-            "class": "textarea",
+                "placeholder": _(
+                    "Please provide clear feedback if you decided to not "
+                    "approve this %s."
+                )
+                % self.resource_name,
+                "rows": "5",
+                "class": "textarea",
             }
         )
 
@@ -52,9 +53,13 @@ class ResourceBaseCleanFileForm(object):
         file = self.cleaned_data["file"]
         file_extension = os.path.splitext(file.name)[1]
         is_gpkg = file_extension == ".gpkg"
-        is_map = getattr(self, 'is_map', False)
-        is_screenshot = getattr(self, 'is_screenshot', False)
+        is_map = getattr(self, "is_map", False)
+        is_screenshot = getattr(self, "is_screenshot", False)
         is_map_or_screenshot = is_map or is_screenshot
-        is_3d = getattr(self, 'is_3d', False)
-        if filesize_validator(file.file, is_gpkg, is_map_or_screenshot, is_3d):
+        is_3d = getattr(self, "is_3d", False)
+        is_thumbnail = getattr(self, "is_thumbnail", False)
+
+        if filesize_validator(
+            file.file, is_gpkg, is_map_or_screenshot, is_3d, is_thumbnail=is_thumbnail
+        ):
             return file

--- a/qgis-app/base/validator.py
+++ b/qgis-app/base/validator.py
@@ -9,12 +9,21 @@ GPKG_MAX_SIZE = getattr(settings, "GPKG_MAX_SIZE", 5000000)  # 5MB
 MODEL_3D_MAX_SIZE = getattr(settings, "MODEL_3D_MAX_SIZE", 5000000)  # 5MB
 MAP_MAX_SIZE = getattr(settings, "MAP_MAX_UPLOAD_SIZE", 10000000)  # 10 mb
 
+THUMBNAIL_MAX_SIZE = getattr(settings, "THUMBNAIL_MAX_SIZE", 2000000)  # 2MB
 
-def filesize_validator(file, is_gpkg=False, is_map_or_screenshot=False, is_3d=False) -> bool:
+
+def filesize_validator(
+    file,
+    is_gpkg=False,
+    is_map_or_screenshot=False,
+    is_3d=False,
+    is_thumbnail=False,
+) -> bool:
     """File Size Validation"""
     max_size = GPKG_MAX_SIZE if is_gpkg else RESOURCE_MAX_SIZE
     max_size = MAP_MAX_SIZE if is_map_or_screenshot else max_size
     max_size = MODEL_3D_MAX_SIZE if is_3d else max_size
+    max_size = THUMBNAIL_MAX_SIZE if is_thumbnail else max_size
 
     error_filesize_too_big = ValidationError(
         _("File is too big. Max size is %s Megabytes") % (max_size / 1000000)

--- a/qgis-app/geopackages/models.py
+++ b/qgis-app/geopackages/models.py
@@ -17,7 +17,7 @@ class Geopackage(Resource):
     # file
     file = models.FileField(
         _("GeoPackage file"),
-        help_text=_("A GeoPackage file. The filesize must less than 5MB "),
+        help_text=_("A GeoPackage file. The filesize must be less than 5MB."),
         upload_to=GEOPACKAGES_STORAGE_PATH,
         validators=[FileExtensionValidator(allowed_extensions=["gpkg", "zip"])],
         null=False,
@@ -26,7 +26,9 @@ class Geopackage(Resource):
     # thumbnail
     thumbnail_image = models.ImageField(
         _("Thumbnail"),
-        help_text=_("Please upload an image that demonstrate this resource."),
+        help_text=_(
+            "Please upload an image that demonstrate this resource. Max size is 2MB."
+        ),
         blank=False,
         null=False,
         upload_to=GEOPACKAGES_STORAGE_PATH,

--- a/qgis-app/layerdefinitions/models.py
+++ b/qgis-app/layerdefinitions/models.py
@@ -18,7 +18,7 @@ class LayerDefinition(Resource):
     # file
     file = models.FileField(
         _("Layer Definition file"),
-        help_text=_("A Layer Definition file. " "The filesize must less than 1MB"),
+        help_text=_("A Layer Definition file. " "The filesize must be less than 1MB."),
         upload_to=LAYERDEFINITIONS_STORAGE_PATH,
         validators=[FileExtensionValidator(allowed_extensions=["qlr"])],
         null=False,
@@ -27,7 +27,9 @@ class LayerDefinition(Resource):
     # thumbnail
     thumbnail_image = models.ImageField(
         _("Thumbnail"),
-        help_text=_("Please upload an image that demonstrate this resource."),
+        help_text=_(
+            "Please upload an image that demonstrate this resource. Max size is 2MB."
+        ),
         blank=False,
         null=False,
         upload_to=LAYERDEFINITIONS_STORAGE_PATH,

--- a/qgis-app/models/models.py
+++ b/qgis-app/models/models.py
@@ -19,7 +19,9 @@ class Model(Resource):
     # thumbnail
     thumbnail_image = models.ImageField(
         _("Thumbnail"),
-        help_text=_("Please upload an image that demonstrate this Model"),
+        help_text=_(
+            "Please upload an image that demonstrate this Model. Max size is 2MB."
+        ),
         blank=False,
         null=False,
         upload_to=MODELS_STORAGE_PATH,
@@ -28,7 +30,7 @@ class Model(Resource):
     # file
     file = models.FileField(
         _("Model file"),
-        help_text=_("A Model file. The filesize must less than 1MB "),
+        help_text=_("A Model file. The filesize must be less than 1MB."),
         upload_to=MODELS_STORAGE_PATH,
         validators=[FileExtensionValidator(allowed_extensions=["model3", "zip"])],
         null=False,
@@ -41,7 +43,6 @@ class Model(Resource):
         blank=True,
         null=True,
     )
-
 
     def extension(self):
         name, extension = os.path.splitext(self.file.name)

--- a/qgis-app/processing_scripts/models.py
+++ b/qgis-app/processing_scripts/models.py
@@ -1,54 +1,58 @@
+import os
+
 from base.models.processing_models import Resource, ResourceReview
-from django.db import models
 from django.conf import settings
+from django.core.validators import FileExtensionValidator
+from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from django.core.validators import FileExtensionValidator
-import os
 
 SCRIPTS_STORAGE_PATH = getattr(settings, "HUB_STORAGE_PATH", "processing_scripts/%Y")
 
+
 class ProcessingScript(Resource):
-  """
-  Model for storing processing scripts
-  """
-  # thumbnail
-  thumbnail_image = models.ImageField(
-      _("Thumbnail"),
-      help_text=_("Please upload an image that demonstrate this Script"),
-      blank=False,
-      null=False,
-      upload_to=SCRIPTS_STORAGE_PATH,
-  )
+    """
+    Model for storing processing scripts
+    """
 
-  # file
-  file = models.FileField(
-      _("Processing script file"),
-      help_text=_("A Python file. The filesize must less than 1MB "),
-      upload_to=SCRIPTS_STORAGE_PATH,
-      validators=[FileExtensionValidator(allowed_extensions=["py"])],
-      null=False,
-  )
+    # thumbnail
+    thumbnail_image = models.ImageField(
+        _("Thumbnail"),
+        help_text=_(
+            "Please upload an image that demonstrate this Script. Max size is 2MB."
+        ),
+        blank=False,
+        null=False,
+        upload_to=SCRIPTS_STORAGE_PATH,
+    )
 
-  # plugin dependencies
-  dependencies = models.TextField(
-      _("Plugin dependencies"),
-      help_text=_("Comma-separated list for the plugin the script needs"),
-      blank=True,
-      null=True,
-  )
+    # file
+    file = models.FileField(
+        _("Processing script file"),
+        help_text=_("A Python file. The filesize must be less than 1MB."),
+        upload_to=SCRIPTS_STORAGE_PATH,
+        validators=[FileExtensionValidator(allowed_extensions=["py"])],
+        null=False,
+    )
 
+    # plugin dependencies
+    dependencies = models.TextField(
+        _("Plugin dependencies"),
+        help_text=_("Comma-separated list for the plugin the script needs"),
+        blank=True,
+        null=True,
+    )
 
-  def extension(self):
-    name, extension = os.path.splitext(self.file.name)
-    return extension
+    def extension(self):
+        name, extension = os.path.splitext(self.file.name)
+        return extension
 
-  def get_absolute_url(self):
-    return reverse("processing_script_detail", args=(self.id,))
+    def get_absolute_url(self):
+        return reverse("processing_script_detail", args=(self.id,))
 
-  def get_file_content(self):
-    with open(self.file.path, 'r') as file:
-      return file.read()
+    def get_file_content(self):
+        with open(self.file.path, "r") as file:
+            return file.read()
 
 
 class Review(ResourceReview):

--- a/qgis-app/styles/models.py
+++ b/qgis-app/styles/models.py
@@ -121,7 +121,7 @@ class Style(Resource):
         _("Thumbnail"),
         help_text=_(
             "Please upload an image that represents this style. "
-            "The image should be square when uploaded."
+            "The image should be square when uploaded. Max size is 2MB."
         ),
         blank=True,
         null=True,
@@ -131,7 +131,9 @@ class Style(Resource):
     # file
     file = models.FileField(
         _("Style file"),
-        help_text=_("Upload a QGIS Style (.xml) or a Color Palette (.gpl) file."),
+        help_text=_(
+            "Upload a QGIS Style (.xml) or a Color Palette (.gpl) file. The filesize must be less than 1MB."
+        ),
         upload_to=STYLES_STORAGE_PATH,
         validators=[FileExtensionValidator(allowed_extensions=["xml", "gpl"])],
         null=False,

--- a/qgis-app/wavefronts/models.py
+++ b/qgis-app/wavefronts/models.py
@@ -21,7 +21,9 @@ class Wavefront(Resource):
     # thumbnail
     thumbnail_image = models.ImageField(
         _("Thumbnail"),
-        help_text=_("Please upload an image that demonstrate this 3D Model"),
+        help_text=_(
+            "Please upload an image that demonstrate this 3D Model. Max size is 2MB."
+        ),
         blank=False,
         null=False,
         upload_to=WAVEFRONTS_STORAGE_PATH,
@@ -31,7 +33,7 @@ class Wavefront(Resource):
     file = models.FileField(
         _("3D Model file"),
         help_text=_(
-            "A 3D model zip file. The zip file must contains obj and mtl files"
+            "A 3D model zip file. The zip file must contains obj and mtl files. The filesize must be less than 1MB."
         ),
         upload_to=WAVEFRONTS_STORAGE_PATH,
         validators=[FileExtensionValidator(allowed_extensions=["zip"])],


### PR DESCRIPTION
Closes #119 

- This will mention the file size limit in the Upload Style and Upload Model forms (no changes to the size limit yet, just mention them). 
- Also, this will add an explicit file size limit of 2MB to the thumbnail image in each Upload form.

<img width="749" height="222" alt="image" src="https://github.com/user-attachments/assets/bc4bd53b-e30e-4d3d-a260-d1c76bdcffad" />
