### PR TITLE
Increase QLR and styles size limit to 5MB

### DIFF
--- a/qgis-app/base/forms/processing_forms.py
+++ b/qgis-app/base/forms/processing_forms.py
@@ -58,8 +58,16 @@ class ResourceBaseCleanFileForm(object):
         is_map_or_screenshot = is_map or is_screenshot
         is_3d = getattr(self, "is_3d", False)
         is_thumbnail = getattr(self, "is_thumbnail", False)
+        is_layerdefinition = getattr(self, "is_layerdefinition", False)
+        is_style = getattr(self, "is_style", False)
 
         if filesize_validator(
-            file.file, is_gpkg, is_map_or_screenshot, is_3d, is_thumbnail=is_thumbnail
+            file.file,
+            is_gpkg,
+            is_map_or_screenshot,
+            is_3d,
+            is_thumbnail=is_thumbnail,
+            is_layerdefinition=is_layerdefinition,
+            is_style=is_style,
         ):
             return file

--- a/qgis-app/base/validator.py
+++ b/qgis-app/base/validator.py
@@ -4,12 +4,18 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
-RESOURCE_MAX_SIZE = getattr(settings, "RESOURCE_MAX_SIZE", 1000000)  # 1MB
-GPKG_MAX_SIZE = getattr(settings, "GPKG_MAX_SIZE", 5000000)  # 5MB
-MODEL_3D_MAX_SIZE = getattr(settings, "MODEL_3D_MAX_SIZE", 5000000)  # 5MB
-MAP_MAX_SIZE = getattr(settings, "MAP_MAX_UPLOAD_SIZE", 10000000)  # 10 mb
+# Conversion constant
+BYTES_TO_MB = 1_000_000
 
-THUMBNAIL_MAX_SIZE = getattr(settings, "THUMBNAIL_MAX_SIZE", 2000000)  # 2MB
+# Default file size limits (in bytes)
+RESOURCE_MAX_SIZE = getattr(settings, "RESOURCE_MAX_SIZE", 1 * BYTES_TO_MB)  # 1MB
+GPKG_MAX_SIZE = getattr(settings, "GPKG_MAX_SIZE", 5 * BYTES_TO_MB)  # 5MB
+MODEL_3D_MAX_SIZE = getattr(settings, "MODEL_3D_MAX_SIZE", 5 * BYTES_TO_MB)  # 5MB
+MAP_MAX_SIZE = getattr(settings, "MAP_MAX_UPLOAD_SIZE", 10 * BYTES_TO_MB)  # 10MB
+QLR_MAX_SIZE = getattr(settings, "QLR_MAX_SIZE", 5 * BYTES_TO_MB)  # 5MB
+STYLE_MAX_SIZE = getattr(settings, "STYLE_MAX_SIZE", 5 * BYTES_TO_MB)  # 5MB
+
+THUMBNAIL_MAX_SIZE = getattr(settings, "THUMBNAIL_MAX_SIZE", 2 * BYTES_TO_MB)  # 2MB
 
 
 def filesize_validator(
@@ -18,15 +24,19 @@ def filesize_validator(
     is_map_or_screenshot=False,
     is_3d=False,
     is_thumbnail=False,
+    is_layerdefinition=False,
+    is_style=False,
 ) -> bool:
     """File Size Validation"""
     max_size = GPKG_MAX_SIZE if is_gpkg else RESOURCE_MAX_SIZE
     max_size = MAP_MAX_SIZE if is_map_or_screenshot else max_size
     max_size = MODEL_3D_MAX_SIZE if is_3d else max_size
     max_size = THUMBNAIL_MAX_SIZE if is_thumbnail else max_size
+    max_size = QLR_MAX_SIZE if is_layerdefinition else max_size
+    max_size = STYLE_MAX_SIZE if is_style else max_size
 
     error_filesize_too_big = ValidationError(
-        _("File is too big. Max size is %s Megabytes") % (max_size / 1000000)
+        _("File is too big. Max size is %s Megabytes") % (max_size / BYTES_TO_MB)
     )
     try:
         if file.getbuffer().nbytes > max_size:

--- a/qgis-app/layerdefinitions/forms.py
+++ b/qgis-app/layerdefinitions/forms.py
@@ -7,6 +7,8 @@ from taggit.forms import TagField
 
 class ResourceFormMixin(forms.ModelForm):
     tags = TagField(required=False)
+    is_layerdefinition = True
+
     class Meta:
         model = LayerDefinition
         fields = [
@@ -16,7 +18,7 @@ class ResourceFormMixin(forms.ModelForm):
             "url_metadata",
             "description",
             "license",
-            "tags"
+            "tags",
         ]
 
 

--- a/qgis-app/layerdefinitions/models.py
+++ b/qgis-app/layerdefinitions/models.py
@@ -18,7 +18,7 @@ class LayerDefinition(Resource):
     # file
     file = models.FileField(
         _("Layer Definition file"),
-        help_text=_("A Layer Definition file. " "The filesize must be less than 1MB."),
+        help_text=_("A Layer Definition file. " "The filesize must be less than 5MB."),
         upload_to=LAYERDEFINITIONS_STORAGE_PATH,
         validators=[FileExtensionValidator(allowed_extensions=["qlr"])],
         null=False,

--- a/qgis-app/styles/forms.py
+++ b/qgis-app/styles/forms.py
@@ -1,36 +1,33 @@
+from base.forms.processing_forms import ResourceBaseCleanFileForm
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
-from styles.file_handler import validator, gpl_validator
+from styles.file_handler import gpl_validator, validator
 from styles.models import Style
 from taggit.forms import TagField
-from base.forms.processing_forms import ResourceBaseCleanFileForm
 
 
 class ResourceFormMixin(forms.ModelForm):
     tags = TagField(required=False)
+    is_style = True
+
     class Meta:
         model = Style
-        fields = [
-            "file",
-            "thumbnail_image",
-            "name",
-            "description",
-            "tags"
-        ]
+        fields = ["file", "thumbnail_image", "name", "description", "tags"]
 
 
 class UploadForm(ResourceBaseCleanFileForm, ResourceFormMixin):
     """
     Style Upload Form.
     """
+
     def clean_file(self):
         """
         Cleaning file field data.
         """
 
         style_file = super(UploadForm, self).clean_file()
-        if style_file.name.lower().endswith('.gpl'):
+        if style_file.name.lower().endswith(".gpl"):
             gpl_validator(style_file)
         else:
             style = validator(style_file.file)
@@ -48,9 +45,9 @@ class UpdateForm(ResourceBaseCleanFileForm, ResourceFormMixin):
         """
         Cleaning file field data only if the file has been updated.
         """
-        if 'file' in self.changed_data:
+        if "file" in self.changed_data:
             style_file = super(UpdateForm, self).clean_file()
-            if style_file.name.lower().endswith('.gpl'):
+            if style_file.name.lower().endswith(".gpl"):
                 gpl_validator(style_file)
             else:
                 style = validator(style_file.file)
@@ -59,7 +56,8 @@ class UpdateForm(ResourceBaseCleanFileForm, ResourceFormMixin):
                         _("Undefined style type. " "Please register your style type.")
                     )
             return style_file
-        return self.cleaned_data.get('file')
+        return self.cleaned_data.get("file")
+
 
 class StyleReviewForm(forms.Form):
     """

--- a/qgis-app/styles/models.py
+++ b/qgis-app/styles/models.py
@@ -132,7 +132,7 @@ class Style(Resource):
     file = models.FileField(
         _("Style file"),
         help_text=_(
-            "Upload a QGIS Style (.xml) or a Color Palette (.gpl) file. The filesize must be less than 1MB."
+            "Upload a QGIS Style (.xml) or a Color Palette (.gpl) file. The filesize must be less than 5MB."
         ),
         upload_to=STYLES_STORAGE_PATH,
         validators=[FileExtensionValidator(allowed_extensions=["xml", "gpl"])],


### PR DESCRIPTION
Close #99 

I think it should be possible to consider the request to increase the QLR size limit to 5MB, as we still have enough resources on the media storage, and there is only a small number of layer definitions. For the style files, I would also suggest increasing the size limit to 5MB. However, as they are the primary uploaded resource type and currently count 150+ files, having a higher limit would quickly fill up the media storage.

Please note that we also have this 5MB limit for 3D models and GPKG projects.